### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -108,3 +108,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -102,7 +102,7 @@ def signup_for_activity(activity_name: str, email: str):
     if email in activity["participants"]:
         raise HTTPException(status_code=400, detail="Student is already signed up for this activity")
 
-    # Validate student is not already signed up
+    # Validate activity is not full
     if len(activity["participants"]) >= activity["max_participants"]:
         raise HTTPException(status_code=400, detail="Activity is full")
     # Add student

--- a/src/app.py
+++ b/src/app.py
@@ -21,25 +21,61 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        },
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 25,
+            "participants": []
+        },
+        "Swimming Club": {
+            "description": "Improve swimming techniques and participate in competitions",
+            "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+            "max_participants": 20,
+            "participants": []
+        },
+        "Art Studio": {
+            "description": "Explore various art mediums including painting and sculpture",
+            "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": []
+        },
+        "Drama Club": {
+            "description": "Perform in plays and learn acting techniques",
+            "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+            "max_participants": 18,
+            "participants": []
+        },
+        "Debate Team": {
+            "description": "Develop critical thinking and public speaking skills through debates",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 16,
+            "participants": []
+        },
+        "Robotics Club": {
+            "description": "Build and program robots for competitions",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": []
+        }
     }
-}
 
 
 @app.get("/")
@@ -62,6 +98,13 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up for this activity")
+
+    # Validate student is not already signed up
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is full")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,12 +19,22 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        
+        const participantsList = details.participants.length > 0
+          ? `<ul class="participants-list">
+              ${details.participants.map(email => `<li>${email}</li>`).join('')}
+            </ul>`
+          : `<p class="no-participants">No participants yet - be the first to join!</p>`;
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants (${details.participants.length}/${details.max_participants}):</strong>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -22,7 +22,14 @@ document.addEventListener("DOMContentLoaded", () => {
         
         const participantsList = details.participants.length > 0
           ? `<ul class="participants-list">
-              ${details.participants.map(email => `<li>${email}</li>`).join('')}
+              ${details.participants.map(email => `
+                <li>
+                  <span class="participant-email">${email}</span>
+                  <button class="delete-btn" data-activity="${name}" data-email="${email}" title="Unregister ${email}">
+                    🗑️
+                  </button>
+                </li>
+              `).join('')}
             </ul>`
           : `<p class="no-participants">No participants yet - be the first to join!</p>`;
 
@@ -72,6 +79,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh activities list to show the new participant
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -88,6 +97,51 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle delete button clicks
+  activitiesList.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("delete-btn")) {
+      const email = event.target.dataset.email;
+      const activity = event.target.dataset.activity;
+
+      if (!confirm(`Are you sure you want to unregister ${email} from ${activity}?`)) {
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+          {
+            method: "DELETE",
+          }
+        );
+
+        const result = await response.json();
+
+        if (response.ok) {
+          messageDiv.textContent = result.message;
+          messageDiv.className = "success";
+          // Refresh activities list
+          await fetchActivities();
+        } else {
+          messageDiv.textContent = result.detail || "An error occurred";
+          messageDiv.className = "error";
+        }
+
+        messageDiv.classList.remove("hidden");
+
+        // Hide message after 5 seconds
+        setTimeout(() => {
+          messageDiv.classList.add("hidden");
+        }, 5000);
+      } catch (error) {
+        messageDiv.textContent = "Failed to unregister. Please try again.";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        console.error("Error unregistering:", error);
+      }
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,43 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-section strong {
+  color: #1a237e;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.participants-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.participants-list li {
+  padding: 6px 10px;
+  margin: 4px 0;
+  background-color: #e8eaf6;
+  border-left: 3px solid #1a237e;
+  border-radius: 3px;
+  font-size: 14px;
+  color: #555;
+}
+
+.no-participants {
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-radius: 3px;
+  font-style: italic;
+  color: #888;
+  margin: 8px 0 0 0;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -100,6 +100,32 @@ section h3 {
   border-radius: 3px;
   font-size: 14px;
   color: #555;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.participant-email {
+  flex-grow: 1;
+}
+
+.delete-btn {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px 8px;
+  transition: transform 0.2s, opacity 0.2s;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.delete-btn:hover {
+  background-color: #ffcdd2;
+  border-radius: 4px;
+  transform: scale(1.1);
+  opacity: 1;
 }
 
 .no-participants {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,232 @@
+"""
+Tests for the Mergington High School API
+"""
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+@pytest.fixture
+def client():
+    """Create a test client"""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities to initial state before each test"""
+    activities.clear()
+    activities.update({
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        },
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 25,
+            "participants": []
+        },
+    })
+
+
+class TestRootEndpoint:
+    """Tests for the root endpoint"""
+    
+    def test_root_redirects_to_static(self, client):
+        """Test that root redirects to static/index.html"""
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"
+
+
+class TestGetActivities:
+    """Tests for GET /activities endpoint"""
+    
+    def test_get_all_activities(self, client):
+        """Test retrieving all activities"""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        data = response.json()
+        assert "Chess Club" in data
+        assert "Programming Class" in data
+        assert "Gym Class" in data
+        assert "Soccer Team" in data
+    
+    def test_activities_have_correct_structure(self, client):
+        """Test that activities have required fields"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        for activity_name, activity_data in data.items():
+            assert "description" in activity_data
+            assert "schedule" in activity_data
+            assert "max_participants" in activity_data
+            assert "participants" in activity_data
+            assert isinstance(activity_data["participants"], list)
+
+
+class TestSignupForActivity:
+    """Tests for POST /activities/{activity_name}/signup endpoint"""
+    
+    def test_signup_success(self, client):
+        """Test successful signup for an activity"""
+        response = client.post(
+            "/activities/Soccer Team/signup?email=newstudent@mergington.edu"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "newstudent@mergington.edu" in data["message"]
+        
+        # Verify student was added
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "newstudent@mergington.edu" in activities_data["Soccer Team"]["participants"]
+    
+    def test_signup_for_nonexistent_activity(self, client):
+        """Test signup for an activity that doesn't exist"""
+        response = client.post(
+            "/activities/NonExistent/signup?email=student@mergington.edu"
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Activity not found"
+    
+    def test_signup_already_registered(self, client):
+        """Test signup when student is already registered"""
+        response = client.post(
+            "/activities/Chess Club/signup?email=michael@mergington.edu"
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Student is already signed up for this activity"
+    
+    def test_signup_when_activity_full(self, client):
+        """Test signup when activity is at max capacity"""
+        # Fill up Soccer Team
+        for i in range(25):
+            activities["Soccer Team"]["participants"].append(f"student{i}@mergington.edu")
+        
+        response = client.post(
+            "/activities/Soccer Team/signup?email=newstudent@mergington.edu"
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Activity is full"
+    
+    def test_signup_with_url_encoded_activity_name(self, client):
+        """Test signup with URL-encoded activity name"""
+        response = client.post(
+            "/activities/Chess%20Club/signup?email=newstudent@mergington.edu"
+        )
+        assert response.status_code == 200
+
+
+class TestUnregisterFromActivity:
+    """Tests for DELETE /activities/{activity_name}/unregister endpoint"""
+    
+    def test_unregister_success(self, client):
+        """Test successful unregistration from an activity"""
+        response = client.delete(
+            "/activities/Chess Club/unregister?email=michael@mergington.edu"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "michael@mergington.edu" in data["message"]
+        
+        # Verify student was removed
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "michael@mergington.edu" not in activities_data["Chess Club"]["participants"]
+    
+    def test_unregister_from_nonexistent_activity(self, client):
+        """Test unregister from an activity that doesn't exist"""
+        response = client.delete(
+            "/activities/NonExistent/unregister?email=student@mergington.edu"
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] == "Activity not found"
+    
+    def test_unregister_not_registered(self, client):
+        """Test unregister when student is not registered"""
+        response = client.delete(
+            "/activities/Soccer Team/unregister?email=notregistered@mergington.edu"
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Student is not signed up for this activity"
+    
+    def test_unregister_with_url_encoded_activity_name(self, client):
+        """Test unregister with URL-encoded activity name"""
+        response = client.delete(
+            "/activities/Chess%20Club/unregister?email=michael@mergington.edu"
+        )
+        assert response.status_code == 200
+
+
+class TestIntegrationScenarios:
+    """Integration tests for complete user scenarios"""
+    
+    def test_signup_and_unregister_flow(self, client):
+        """Test complete flow of signing up and then unregistering"""
+        email = "testuser@mergington.edu"
+        activity = "Programming Class"
+        
+        # Sign up
+        signup_response = client.post(
+            f"/activities/{activity}/signup?email={email}"
+        )
+        assert signup_response.status_code == 200
+        
+        # Verify signup
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert email in activities_data[activity]["participants"]
+        
+        # Unregister
+        unregister_response = client.delete(
+            f"/activities/{activity}/unregister?email={email}"
+        )
+        assert unregister_response.status_code == 200
+        
+        # Verify unregistration
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert email not in activities_data[activity]["participants"]
+    
+    def test_multiple_signups_different_activities(self, client):
+        """Test that a student can sign up for multiple different activities"""
+        email = "multitask@mergington.edu"
+        
+        # Sign up for multiple activities
+        activities_to_join = ["Chess Club", "Programming Class", "Soccer Team"]
+        
+        for activity in activities_to_join:
+            response = client.post(
+                f"/activities/{activity}/signup?email={email}"
+            )
+            assert response.status_code == 200
+        
+        # Verify all signups
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        
+        for activity in activities_to_join:
+            assert email in activities_data[activity]["participants"]


### PR DESCRIPTION
This pull request adds support for unregistering students from activities, improves the frontend to display and manage activity participants, and introduces automated tests for the API. The backend now allows students to be removed from activities, while the UI provides participant lists and an option to unregister. Comprehensive tests ensure the reliability of the new and existing features.

**Backend enhancements:**

* Added a new `DELETE /activities/{activity_name}/unregister` endpoint to allow students to unregister from activities, with validation for activity existence and registration status.
* Improved the signup logic to prevent duplicate registrations and enforce activity capacity limits.

**Frontend improvements:**

* Updated the activity cards to show a list of participants for each activity, including an "unregister" (delete) button next to each participant.
* Implemented frontend logic to handle participant removal via the new backend endpoint, including confirmation prompts and UI refreshes. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R103-R147) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R82-R83)
* Enhanced styles for participant lists and unregister buttons for better usability and appearance.

**Testing:**

* Added a comprehensive test suite in `tests/test_api.py` to cover activity listing, signup, unregistration, and integration flows, ensuring the correctness of the new unregister feature and existing endpoints. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1-R232) [[2]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1)

**Data updates:**

* Expanded the set of available activities in `src/app.py` to include Soccer Team, Swimming Club, Art Studio, Drama Club, Debate Team, and Robotics Club.